### PR TITLE
Fix segmentation fault when adding credentials

### DIFF
--- a/gnutls/src/lib.rs
+++ b/gnutls/src/lib.rs
@@ -180,7 +180,7 @@ impl Session {
         unsafe {
             let res: i32 = gnutls_credentials_set(self.session,
                                                   cred_type,
-                                                  mem::transmute(&creds.credentials));
+                                                  mem::transmute(creds.credentials));
 
             self.creds = true;
             is_succ!(res)


### PR DESCRIPTION
The set_creds() function for the session causes a segmentation due to
the gnutls_credentials_set() C function expecting to receive a
gnutls_certificate_credentials_t rather than a pointer to a
gnutls_certificate_credentials_t.
