### PR TITLE
Add x509_set_system_trust()

### DIFF
--- a/examples/client/src/main.rs
+++ b/examples/client/src/main.rs
@@ -23,8 +23,8 @@ fn main() {
     let mut creds: Cert = Cert::new().unwrap();
     let mut session: Session = Session::new(gnutls::GNUTLS_CLIENT).unwrap();
 
-    if creds.x509_set_trust_file("../../gnutls/tests/ca.cert.pem", None).err() != None {
-        panic!("Error: couldn't set the trust file.");
+    if creds.x509_set_system_trust().err() != None {
+        panic!("Error: couldn't set system trust.");
     }
 
     if creds.x509_set_key_file("../../gnutls/tests/ca.cert.pem",

--- a/gnutls/src/creds.rs
+++ b/gnutls/src/creds.rs
@@ -15,6 +15,7 @@ use gt::gen::{gnutls_x509_crt_fmt_t,
               gnutls_certificate_credentials_t,
               gnutls_certificate_allocate_credentials,
               gnutls_certificate_free_credentials,
+              gnutls_certificate_set_x509_system_trust,
               gnutls_certificate_set_x509_trust_file,
               gnutls_certificate_set_x509_trust_dir,
               gnutls_certificate_set_x509_key_file
@@ -44,6 +45,19 @@ impl Cert {
                 trust_file: false,
                 key_file: false
             })
+        }
+    }
+
+    pub fn x509_set_system_trust(&mut self) -> Result<i32, Error> {
+        unsafe {
+            let processed: i32 = gnutls_certificate_set_x509_system_trust(
+                self.credentials);
+
+            if processed < 0 {
+                Err(processed.as_gnutls_error())
+            } else {
+                Ok(processed)
+            }
         }
     }
 
@@ -137,6 +151,8 @@ mod tests {
                 panic!("Could not initialize the certificate.")
             }
         };
+
+        assert!(cert.x509_set_system_trust().ok().unwrap() > 0);
 
         assert_eq!(Error::FileError,
                    cert.x509_set_trust_file("tests/does_not_exist.pem", None)


### PR DESCRIPTION
This adds the x509_set_system_trust() function to the certificate credentials, and also uses it in the example. I think it is a good idea to encourage users of the library to use this function over having to handle os specific paths themselves.

I did not add a new field to `gnutls::Cert` since I do not understand what use the flags that are already there serve.
