### PR TITLE
Remove bitflags dependency from example code

### DIFF
--- a/examples/client/Cargo.lock
+++ b/examples/client/Cargo.lock
@@ -2,7 +2,6 @@
 name = "client"
 version = "0.1.0"
 dependencies = [
- "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gnutls 0.1.3",
 ]
 

--- a/examples/client/Cargo.toml
+++ b/examples/client/Cargo.toml
@@ -4,5 +4,4 @@ version = "0.1.0"
 authors = ["Bheesham Persaud <bheesham.persaud@live.ca>"]
 
 [dependencies]
-bitflags = "0.4.0"
 gnutls = { path = "../../gnutls" }

--- a/examples/client/src/main.rs
+++ b/examples/client/src/main.rs
@@ -1,4 +1,3 @@
-extern crate bitflags;
 extern crate gnutls;
 
 use gnutls::creds::{Cert, CredType};


### PR DESCRIPTION
The example code does not use the bitflags crate directly.
